### PR TITLE
Make z3c.relationfield imports conditional.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Make z3c.relationfield imports conditional.
+  [jone]
 
 
 1.5 (2015-05-26)

--- a/transmogrify/dexterity/converters.py
+++ b/transmogrify/dexterity/converters.py
@@ -5,9 +5,6 @@ from plone.app.textfield.interfaces import IRichText
 from plone.app.textfield.value import RichTextValue
 from plone.namedfile.interfaces import INamedField
 from plone.supermodel.interfaces import IToUnicode
-from z3c.relationfield.interfaces import IRelation
-from z3c.relationfield.interfaces import IRelationList
-from z3c.relationfield.relation import RelationValue
 from zope.component import adapter
 from zope.component import queryUtility
 from zope.dottedname.resolve import resolve
@@ -29,6 +26,16 @@ except pkg_resources.DistributionNotFound:
 else:
     INTID_AVAILABLE = True
     from zope.app.intid.interfaces import IIntIds
+
+try:
+    pkg_resources.get_distribution('z3c.relationfield')
+except:
+    RELATIONFIELD_AVAILABLE = False
+else:
+    RELATIONFIELD_AVAILABLE = True
+    from z3c.relationfield.interfaces import IRelation
+    from z3c.relationfield.interfaces import IRelationList
+    from z3c.relationfield.relation import RelationValue
 
 
 def get_site_encoding():
@@ -424,7 +431,7 @@ class DefaultDeserializer(object):
         return value
 
 
-if INTID_AVAILABLE:
+if INTID_AVAILABLE and RELATIONFIELD_AVAILABLE:
     @implementer(IDeserializer)
     @adapter(IRelation)
     class RelationDeserializer(object):

--- a/transmogrify/dexterity/converters.zcml
+++ b/transmogrify/dexterity/converters.zcml
@@ -21,8 +21,10 @@
   <adapter factory=".converters.DefaultDeserializer" />
 
   <configure zcml:condition="installed plone.app.intid">
-    <adapter factory=".converters.RelationDeserializer" />
-    <adapter factory=".converters.RelationListDeserializer" />
+      <configure zcml:condition="installed z3c.relationfield">
+          <adapter factory=".converters.RelationDeserializer" />
+          <adapter factory=".converters.RelationListDeserializer" />
+      </configure>
   </configure>
 
 </configure>


### PR DESCRIPTION
z3c.relationfield is no longer shipped with Plone / dexterity,
we therefore should not import from z3c.relationfield when it is not there.