### PR TITLE
Fix default container description to be unicode.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix default container description to be unicode, not bytestring.
+  See https://github.com/plone/plone.dexterity/pull/33
+  [jone]
 
 
 1.5.1 (2015-05-27)

--- a/transmogrify/dexterity/schemaupdater.py
+++ b/transmogrify/dexterity/schemaupdater.py
@@ -121,6 +121,14 @@ class DexterityUpdateSection(object):
                     value = getMultiAdapter(
                         (obj, field),
                         interfaces.IDataManager).query()
+
+                    # Fix default description to be an empty unicode instead of
+                    # an empty bytestring because of this bug:
+                    # https://github.com/plone/plone.dexterity/pull/33
+                    if name == 'description' and value == '':
+                        field.set(field.interface(obj), u'')
+                        continue
+
                     if not(value is field.missing_value
                            or value is interfaces.NO_VALUE):
                         continue

--- a/transmogrify/dexterity/tests/schemaupdater.txt
+++ b/transmogrify/dexterity/tests/schemaupdater.txt
@@ -57,6 +57,11 @@ get the filename in a seperated value from the pipeline:
     >>> two.test_file.data == zptlogo
     True
 
+empty default value is of type unicode:
+
+    >>> two.description
+    u''
+
 DateFields:
 
     >>> spam.test_date
@@ -78,4 +83,3 @@ Won't touch already existing values
     u'Spammety spam'
     >>> spam.foo
     u'one value'
-


### PR DESCRIPTION
The description should be unicode, not bytestring.
The validation will fail when it is bytestring.

The problem is that dexterity Container has a wrong default description:
https://github.com/plone/plone.dexterity/pull/33

/cc @phgross  