### PR TITLE
Fix deserializer if datetime is "None"

### DIFF
--- a/transmogrify/dexterity/converters.py
+++ b/transmogrify/dexterity/converters.py
@@ -394,7 +394,10 @@ class DatetimeDeserializer(object):
     def __call__(self, value, filestore, item,
                  disable_constraints=False, logger=None):
         if isinstance(value, basestring):
-            value = DateTime(value).asdatetime()
+            if value == 'None':
+                value = None
+            else:
+                value = DateTime(value).asdatetime()
         try:
             self.field.validate(value)
         except Exception as e:

--- a/transmogrify/dexterity/tests/testconverters.py
+++ b/transmogrify/dexterity/tests/testconverters.py
@@ -215,3 +215,11 @@ class TestDatetimeDeserializer(unittest.TestCase):
             datetime(2015, 12, 31, 17, 59, 59),
             value
         )
+
+    def test_datetime_deserializer_for_not_required_datetime(self):
+        field = Datetime()
+        field.required = False
+        deserializer = IDeserializer(field)
+        value = deserializer('None', None, None)
+
+        self.assertEqual(None, value)


### PR DESCRIPTION
@jone 

FIX

While migration it's possible to get 'None' as a date-value.
The serializer can't handle this.
