### PR TITLE
Refactor schema updater section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Refactor DexterityUpdateSection: Factor out determining default value,
+  getting value from pipeline and updating fields into their own methods.
+  [lgraf]
 
 
 1.6.2 (2016-05-24)


### PR DESCRIPTION
Refactor `DexterityUpdateSection` by extracting functionality out into separate methods.

This allows subclasses to customize this section without having to override the entire `__iter__` method.

This is a pure refactoring, no changes in functionality.