### PR TITLE
avoid generic names as export or import

### DIFF
--- a/transmogrify/dexterity/pipelines/configure.zcml
+++ b/transmogrify/dexterity/pipelines/configure.zcml
@@ -17,13 +17,13 @@
     <include package="quintagroup.transmogrifier" />
 
     <transmogrifier:registerConfig
-        name="import"
+        name="transmogrify.dexterity-import"
         title="Import pipeline configuration"
         description="This imports all dexterity content from a tree of JSON files"
         configuration="import.cfg" />
 
     <transmogrifier:registerConfig
-        name="export"
+        name="transmogrify.dexterity-export"
         title="Export pipeline configuration"
         description="This exports all dexterity content into a tree of JSON files"
         configuration="export.cfg" />


### PR DESCRIPTION
This way, we avoid clashes with other product that register pipelines such as quintagroup.transmogrifier that does the same:

https://github.com/collective/quintagroup.transmogrifier/blob/master/quintagroup/transmogrifier/configure.zcml#L140

https://github.com/collective/quintagroup.transmogrifier/blob/master/quintagroup/transmogrifier/configure.zcml#L159
