### PR TITLE
Fix date deserialization to work with any kind of separator or when it is None.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix date deserialization to work with any kind of separator or when it is None.
+  [gbastien]
 
 
 1.6.3 (2016-10-11)

--- a/transmogrify/dexterity/converters.py
+++ b/transmogrify/dexterity/converters.py
@@ -366,7 +366,10 @@ class DateDeserializer(object):
     def __call__(self, value, filestore, item,
                  disable_constraints=False, logger=None):
         if isinstance(value, basestring):
-            value = datetime.strptime(value, '%Y-%m-%d')
+            if value in ('', 'None'):
+                value = None
+            else:
+                value = DateTime(value).asdatetime().date()
         if isinstance(value, datetime):
             value = value.date()
         try:

--- a/transmogrify/dexterity/tests/testconverters.py
+++ b/transmogrify/dexterity/tests/testconverters.py
@@ -11,6 +11,7 @@ from z3c.relationfield.relation import RelationValue
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope.schema import Datetime
+from zope.schema import Date
 import pprint
 import unittest
 import zope.testing
@@ -197,6 +198,37 @@ class TestRichTextDeserializer(unittest.TestCase):
             "x-application/cow",
             "Content type from dict should override default")
         self.assertEqual(rtv.encoding, "latin-1")
+
+
+class TestDateDeserializer(unittest.TestCase):
+
+    layer = TRANSMOGRIFY_DEXTERITY_FUNCTIONAL_TESTING
+
+    def setUp(test):
+        test.pp = pprint.PrettyPrinter(indent=4)
+        # TODO: This should read the zcml instead
+        zope.component.provideAdapter(converters.DateDeserializer)
+
+    def test_date_deserializer(self):
+        deserializer = IDeserializer(Date())
+        value = deserializer('2015-12-31', None, None)
+        self.assertEqual(
+            datetime.date(datetime(2015, 12, 31)),
+            value
+        )
+        value = deserializer('2015/12/31', None, None)
+        self.assertEqual(
+            datetime.date(datetime(2015, 12, 31)),
+            value
+        )
+
+    def test_date_deserializer_for_not_required_date(self):
+        field = Date()
+        field.required = False
+        deserializer = IDeserializer(field)
+        value = deserializer('None', None, None)
+
+        self.assertEqual(None, value)
 
 
 class TestDatetimeDeserializer(unittest.TestCase):


### PR DESCRIPTION
Hi @hvelarde @lukasgraf 

we had problems migrating date (not datetime) values from Plone 3.3.6 to Plone 5.1.4, here is a fix and tests for it.

Could you please review and merge?

This package is awesome and save us many hours, just needs some love for details and a better structuration of transmogrifier help on docs.plone.org...

Thank you!

Gauthier