### PR TITLE
IMasterSelectField to return simply the value

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,8 @@ Actually tested and supported fields
     `DateTime.DateTime` e.g. "2015-12-31 17:59:59"
     or "2004/12/30 00:20:00 GMT+1" etc.
 
+- IMasterSelectField
+
 
 Default pipelines
 =================

--- a/transmogrify/dexterity/converters.py
+++ b/transmogrify/dexterity/converters.py
@@ -465,6 +465,18 @@ class DefaultDeserializer(object):
         return value
 
 
+@implementer(IDeserializer)
+@adapter(IMasterSelectField)
+class MasterSelectFieldDeserializer(object):
+
+    def __init__(self, field):
+        self.field = field
+
+    def __call__(self, value, filestore, item,
+                 disable_constraints=False, logger=None):
+        return value
+
+
 if INTID_AVAILABLE and RELATIONFIELD_AVAILABLE:
     @implementer(IDeserializer)
     @adapter(IRelation)


### PR DESCRIPTION
`IMasterSelectField` fails because they are treated like Objects but they only need to return `value`