### PR TITLE
Don't update object with the same id it already has.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     extras_require={
         'test': [
             'ftw.builder',
+            'plone.api',
             'plone.app.dexterity',
             'plone.app.intid',
             'plone.app.testing',

--- a/src/transmogrify/dexterity/schemaupdater.py
+++ b/src/transmogrify/dexterity/schemaupdater.py
@@ -114,7 +114,14 @@ class DexterityUpdateSection(object):
         name = field.getName()
         value = self.get_value_from_pipeline(field, item)
         if value is not _marker:
-            field.set(field.interface(obj), value)
+            # In Plone 5+ if we try to update to the same id, Plone will
+            # try to put a different id from the folder object ids.
+            # As the object is also in the folder, it will receive a different
+            # id. For example, if we try to update the id to new-id, the id
+            # the object will get is new-id-1. So we can't update to the same
+            # id.
+            if name != "id" or value != obj.id:
+                field.set(field.interface(obj), value)
             return
 
         # Get the field's current value, if it has one then leave it alone

--- a/src/transmogrify/dexterity/testing.py
+++ b/src/transmogrify/dexterity/testing.py
@@ -122,7 +122,10 @@ class TransmogrifyDexterityLayer(PloneSandboxLayer):
         fti = DexterityFTI('TransmogrifyDexterityFTI')
         fti.schema = 'transmogrify.dexterity.testing.ITestSchema'
         fti.klass = 'plone.dexterity.content.Container'
-        fti.behaviors = ('plone.app.dexterity.behaviors.metadata.IBasic',)
+        fti.behaviors = (
+            'plone.app.dexterity.behaviors.metadata.IBasic',
+            'plone.app.dexterity.behaviors.id.IShortName',
+        )
         self.portal.portal_types._setObject('TransmogrifyDexterityFTI', fti)
         register(fti)
 
@@ -153,7 +156,7 @@ class TransmogrifyDexterityLayer(PloneSandboxLayer):
                              test_date='2010-10-12',
                              test_datetime='2010-10-12 17:59:59',
                              fieldnotchanged='nochange',
-                             ),
+                        ),
                         dict(_path='/two',
                              foo='Bla',
                              _type='TransmogrifyDexterityFTI',
@@ -165,7 +168,13 @@ class TransmogrifyDexterityLayer(PloneSandboxLayer):
                              test_date=date(2010, 0o1, 0o1, ),
                              test_datetime=datetime(2010, 0o1, 0o1, 17, 59, 59),
                              fieldnotchanged='nochange',
-                             ),
+                        ),
+                        dict(_path='/existent',
+                             foo='Existent',
+                             id='existent',
+                             _type='Folder',
+                             title='Existent',
+                        ),
                     )
                 elif sourcecontent == 'onlytitle':
                     self.sample = (

--- a/src/transmogrify/dexterity/tests/schemaupdater.txt
+++ b/src/transmogrify/dexterity/tests/schemaupdater.txt
@@ -10,11 +10,17 @@ Globals:
 
 Do some imports
 
+    >>> from plone import api
     >>> from collective.transmogrifier.meta import registerConfig
     >>> from collective.transmogrifier.transmogrifier import Transmogrifier
     >>> from plone.app.dexterity.behaviors.metadata import IBasic
     >>> from transmogrify.dexterity.testing import zptlogo
     >>> from transmogrify.dexterity.testing import zptlogo_converted
+
+Create object
+
+    >>> api.content.create(portal, 'TransmogrifyDexterityFTI', 'existent')
+    <Container at /plone/existent>
 
 Run transmogrifier pipeline with default settings (pipeline in tests.cfg)
 
@@ -27,6 +33,11 @@ check the generated and updated objects
     >>> spam
     <Container at ...>
     >>> two = portal.get('two')
+
+check already existing id
+
+    >>> portal.get('existent')
+    <Container at /plone/existent>
 
 Standard schema field values:
 


### PR DESCRIPTION
In Plone 5+ if we try to update to the same id, Plone will try to put a different id from the folder object ids.
As the object is also in the folder, it will receive a different id. For example, if we try to update the id to `new-id`, the id the object will get is `new-id-1`. So we can't update to the same id.