### PR TITLE
Update plone.dublincore behavior fields even if the object doesn't have this behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ docs/make.bat
 docs/doctrees
 docs/html
 /pyvenv.cfg
+/share/
+local

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
+- Update plone.dublincore behavior fields, even if the object doesn't have
+  this behavior.
+  [wesleybl]
+
 - Add suport to Python 3.7 and 3.8
   [wesleybl]
 

--- a/base.cfg
+++ b/base.cfg
@@ -65,6 +65,8 @@ recipe = zc.recipe.testrunner
 eggs = ${instance:eggs}
 initialization =
     os.environ['TZ'] = 'UTC'
+    import time
+    time.tzset()
 defaults = ['-s', 'transmogrify.dexterity', '--auto-color', '--auto-progress']
 
 

--- a/src/transmogrify/dexterity/__init__.py
+++ b/src/transmogrify/dexterity/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from Products.CMFPlone.utils import getFSVersionTuple
+
+
+version_tuple = getFSVersionTuple()
+PLONE_VERSION = float('{0}.{1}'.format(version_tuple[0], version_tuple[1]))

--- a/src/transmogrify/dexterity/testing.py
+++ b/src/transmogrify/dexterity/testing.py
@@ -18,7 +18,7 @@ from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.fti import register
 from plone.namedfile.field import NamedFile
 from plone.supermodel import model
-from Products.CMFPlone.utils import getFSVersionTuple
+from transmogrify.dexterity import PLONE_VERSION
 from zope import schema
 from zope.component import provideUtility
 from zope.configuration import xmlconfig
@@ -51,9 +51,6 @@ if six.PY2:
     zptlogo_converted = zptlogo
 else:
     zptlogo_converted = bytes(zptlogo, 'utf-8')
-
-version_tuple = getFSVersionTuple()
-PLONE_VERSION = float('{0}.{1}'.format(version_tuple[0], version_tuple[1]))
 
 
 class FakeImportContext(object):
@@ -156,6 +153,11 @@ class TransmogrifyDexterityLayer(PloneSandboxLayer):
                              test_date='2010-10-12',
                              test_datetime='2010-10-12 17:59:59',
                              fieldnotchanged='nochange',
+                             creators=["user1"],
+                             contributors=["user2"],
+                             language="en",
+                             effective="2020-07-10 10:24:00.000000 UTC",
+                             subjects=["subject1", "subject2"],
                         ),
                         dict(_path='/two',
                              foo='Bla',

--- a/src/transmogrify/dexterity/tests/schemaupdater.txt
+++ b/src/transmogrify/dexterity/tests/schemaupdater.txt
@@ -13,6 +13,7 @@ Do some imports
     >>> from plone import api
     >>> from collective.transmogrifier.meta import registerConfig
     >>> from collective.transmogrifier.transmogrifier import Transmogrifier
+    >>> from DateTime import DateTime
     >>> from plone.app.dexterity.behaviors.metadata import IBasic
     >>> from transmogrify.dexterity.testing import zptlogo
     >>> from transmogrify.dexterity.testing import zptlogo_converted
@@ -89,6 +90,24 @@ DatetimeFields:
 
     >>> two.test_datetime
     datetime.datetime(2010, 1, 1, 17, 59, 59)
+
+Even types that does not have the plone.dublincore behavior must have the
+DublinCore fields populated:
+
+    >>> behaviors = portal.portal_types['TransmogrifyDexterityFTI'].behaviors
+    >>> not any(x in behaviors for x in ['plone.app.dexterity.behaviors.metadata.IDublinCore', 'plone.dublincore'])
+    True
+    >>> spam.creators
+    ('user1',)
+    >>> spam.effective_date
+    DateTime('2020/07/10 10:24:00 UTC')
+    >>> spam.language
+    'en'
+    >>> spam.contributors
+    ('user2',)
+    >>> spam.subject
+    ('subject1', 'subject2')
+
 
 Won't touch already existing values
 

--- a/test_plone43.cfg
+++ b/test_plone43.cfg
@@ -33,3 +33,6 @@ pathlib2 = 2.3.5
 # Required by:
 # pathlib2==2.3.5
 scandir = 1.10.0
+
+# Added by buildout at 2021-08-13 11:56:21.479060
+collective.recipe.cmd = 0.11


### PR DESCRIPTION
Plone fills in and uses the plone.dublincore behavior fields, such as, effective, expires, creators..., even if the object doesn't have this behavior. So content exports must bring these fields even if the object doesn't have the behavior. These changes import these fields in object that doesn't have this behavior, if they are in json.