### PR TITLE
Add option skip_datafields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
+- Add option skip_datafields. When the configuration skip_datafields = True
+  is set, schemaupdater will skip all fields that have the corresponding
+  _datafield_fieldname key.
+  [wesleybl]
+
 - Update plone.dublincore behavior fields, even if the object doesn't have
   this behavior.
   [wesleybl]

--- a/src/transmogrify/dexterity/schemaupdater.py
+++ b/src/transmogrify/dexterity/schemaupdater.py
@@ -58,6 +58,8 @@ class DexterityUpdateSection(object):
         # configured.
         self.datafield_prefix = options.get('datafield-prefix', '_datafield_')
 
+        self.skip_datafields = options.get('skip_datafields', False)
+
         # create logger
         if options.get('logger'):
             self.logger = logging.getLogger(options['logger'])
@@ -124,6 +126,9 @@ class DexterityUpdateSection(object):
             return
 
         name = field.getName()
+        if self.skip_datafields:
+            if "{0}{1}".format(self.datafield_prefix, name) in item:
+                return
         value = self.get_value_from_pipeline(field, item)
         if value is not _marker:
             # In Plone 5+ if we try to update to the same id, Plone will

--- a/src/transmogrify/dexterity/testing.py
+++ b/src/transmogrify/dexterity/testing.py
@@ -77,6 +77,10 @@ class ITestSchema(model.Schema):
         title=u'File',
     )
 
+    test_file2 = NamedFile(
+        title=u'File 2',
+    )
+
     test_date = schema.Date(
         title=u'test_date',
     )
@@ -177,6 +181,11 @@ class TransmogrifyDexterityLayer(PloneSandboxLayer):
                              _type='Folder',
                              title='Existent',
                         ),
+                        dict(_path='/file_object',
+                             _type='TransmogrifyDexterityFTI',
+                             title='File',
+                             _datafield_test_file2="data",
+                        ),
                     )
                 elif sourcecontent == 'onlytitle':
                     self.sample = (
@@ -186,6 +195,15 @@ class TransmogrifyDexterityLayer(PloneSandboxLayer):
                         dict(_path='/two',
                              _type='TransmogrifyDexterityFTI',
                              title='My Awesome Second Object'),
+                    )
+                elif sourcecontent == 'skip_datafields':
+                    self.sample = (
+                        dict(
+                            _path="/file_skip_object",
+                            _type="TransmogrifyDexterityFTI",
+                            title="Skip File",
+                            _datafield_test_file2="0/1.json-file-1",
+                        ),
                     )
         provideUtility(SchemaSource,
                        name=u'transmogrify.dexterity.testsource')

--- a/src/transmogrify/dexterity/tests/schemaupdater.txt
+++ b/src/transmogrify/dexterity/tests/schemaupdater.txt
@@ -26,7 +26,7 @@ Create object
 Run transmogrifier pipeline with default settings (pipeline in tests.cfg)
 
     >>> transmogrifier = Transmogrifier(portal)
-    >>> output = transmogrifier(u'transmogrify.dexterity.testconfiguration')
+    >>> output = transmogrifier('transmogrify.dexterity.testconfiguration')
 
 check the generated and updated objects
 
@@ -70,6 +70,11 @@ get the filename in a seperated value from the pipeline:
     >>> two.test_file.data == zptlogo_converted
     True
 
+get file set whit _datafield_file
+    >>> file_object = portal.get('file_object')
+    >>> file_object.test_file2.data
+    b'data'
+
 empty default value is of type unicode:
 
     >>> two.description
@@ -112,9 +117,9 @@ DublinCore fields populated:
 Won't touch already existing values
 
     >>> transmogrifier = Transmogrifier(portal)
-    >>> output = transmogrifier(u'transmogrify.dexterity.testconfiguration')
+    >>> output = transmogrifier('transmogrify.dexterity.testconfiguration')
     >>> transmogrifier = Transmogrifier(portal)
-    >>> output = transmogrifier(u'transmogrify.dexterity.testconfiguration', definitions={
+    >>> output = transmogrifier('transmogrify.dexterity.testconfiguration', definitions={
     ...     'source-content': 'onlytitle',
     ... })
     >>> spam = portal.get('spam')
@@ -122,3 +127,15 @@ Won't touch already existing values
     'Spammety spam'
     >>> spam.foo
     'one value'
+
+
+When the configuration skip_datafields = True is set, schemaupdater will skip
+all fields that have the corresponding _datafield_fieldname key.
+This is useful when the _datafield_fieldname contains the file path and not the
+base64 of the file.
+
+    >>> transmogrifier = Transmogrifier(portal)
+    >>> output = transmogrifier('transmogrify.dexterity.testskipdatafieds')
+    >>> file_skip_object = portal.get('file_skip_object')
+    >>> file_skip_object.test_file2
+    >>> None

--- a/src/transmogrify/dexterity/tests/skip_datafieds.cfg
+++ b/src/transmogrify/dexterity/tests/skip_datafieds.cfg
@@ -1,0 +1,19 @@
+[transmogrifier]
+pipeline =
+    testsource
+    testcreator
+    schemaupdater
+
+[definitions]
+source-content = skip_datafields
+
+[testsource]
+blueprint = transmogrify.dexterity.testsource
+source-content = ${definitions:source-content}
+
+[testcreator]
+blueprint = collective.transmogrifier.sections.constructor
+
+[schemaupdater]
+blueprint = transmogrify.dexterity.schemaupdater
+skip_datafields = True

--- a/src/transmogrify/dexterity/tests/test_doctests.py
+++ b/src/transmogrify/dexterity/tests/test_doctests.py
@@ -30,6 +30,8 @@ class Py23DocChecker(doctest.OutputChecker):
             got = re.sub("u'", "'", got)
             got = re.sub('u"', '"', got)
 
+            got = re.sub("'data'", "b'data'", got)
+
         return got
 
     def check_output(self, want, got, optionflags):

--- a/src/transmogrify/dexterity/tests/tests.zcml
+++ b/src/transmogrify/dexterity/tests/tests.zcml
@@ -14,4 +14,10 @@
       description="This is an example pipeline configuration"
       configuration="tests.cfg" />
 
+  <transmogrifier:registerConfig
+      name="transmogrify.dexterity.testskipdatafieds"
+      title="Pipeline configuration to skip datafieds"
+      description="This is an example pipeline configuration to skip datafieds"
+      configuration="skip_datafieds.cfg" />
+
 </configure>


### PR DESCRIPTION
When the configuration `skip_datafields = True` is set, schemaupdater will skip all fields that have the corresponding `_datafield_fieldname` key.

This is useful when the `_datafield_fieldname` contains the file path and not the base64 of the file. In this case, the import of the file will be done by another section.

When the `_datafield_fieldname` contains the file path and is not ignored, warnings like:

```
WARNING:plone.namedfile.utils:PIL can not recognize the image. Image is probably broken or of a non-supported format.
```

Since it puts the file path in the file content.

We put the contents of file in a separate file to avoid memory issues on site migrations with very large files.
