### PR TITLE
Import relations fields that were exported as UID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
+- Import relations fields that were exported as UID.
+  [wesleybl]
+
 - Update plone.dublincore behavior fields, even if the object doesn't have
   this behavior.
   [wesleybl]

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'collective.transmogrifier',
         'plone.app.textfield',
         'plone.app.transmogrifier',
+        'plone.app.uuid',
         'plone.dexterity',
         'plone.namedfile',
         'plone.supermodel',

--- a/src/transmogrify/dexterity/converters.py
+++ b/src/transmogrify/dexterity/converters.py
@@ -3,6 +3,7 @@ from DateTime import DateTime
 from datetime import datetime
 from plone.app.textfield.interfaces import IRichText
 from plone.app.textfield.value import RichTextValue
+from plone.app.uuid.utils import uuidToObject
 from plone.namedfile.interfaces import INamedField
 from plone.supermodel.interfaces import IToUnicode
 from transmogrify.dexterity.interfaces import IDeserializer
@@ -500,6 +501,12 @@ if INTID_AVAILABLE and RELATIONFIELD_AVAILABLE:
             return self.deserialize(value)
 
         def deserialize(self, value):
+            if isinstance(value, str):
+                content = uuidToObject(value)
+                if content:
+                    return RelationValue(self.intids.getId(content))
+                else:
+                    return
             int_id = self.intids.queryId(value)
             if int_id is None:
                 return value

--- a/src/transmogrify/dexterity/tests/testconverters.py
+++ b/src/transmogrify/dexterity/tests/testconverters.py
@@ -55,7 +55,7 @@ class TestRelationDeserializer(unittest.TestCase):
         deserializer = IDeserializer(self.relation)
         value = deserializer("bar", None, None)
 
-        self.assertEqual("bar", value)
+        self.assertIsNone(value)
 
     def test_deserialize_relation_list(self):
         folder = create(Builder('folder'))
@@ -85,7 +85,29 @@ class TestRelationDeserializer(unittest.TestCase):
         value = deserializer(["foo"], None, None)
 
         self.assertEqual(1, len(value))
-        self.assertEqual(["foo"], value)
+        self.assertEqual([None], value)
+
+    def test_deserialize_uid_relation(self):
+        folder = create(Builder('folder'))
+        deserializer = IDeserializer(self.relation)
+        value = deserializer(folder.UID(), None, None)
+        self.assertEqual(folder, value.to_object)
+
+    def test_deserialize_uid_relation_list(self):
+        folder = create(Builder('folder'))
+        deserializer = IDeserializer(self.relation_list)
+        value = deserializer([folder.UID()], None, None)
+        self.assertEqual(folder, value[0].to_object)
+
+    def test_deserialize_non_uid_relation(self):
+        deserializer = IDeserializer(self.relation)
+        value = deserializer('09ca9f4fe9304123b05656d9c449b1ad', None, None)
+        self.assertIsNone(value)
+
+    def test_deserialize_non_uid_relation_list(self):
+        deserializer = IDeserializer(self.relation_list)
+        value = deserializer(['f3d11fdbf5a9471796290df759adaab8'], None, None)
+        self.assertEquals([None], value)
 
 
 class TestRichTextDeserializer(unittest.TestCase):


### PR DESCRIPTION
For example, it's possible to have in json something like:

```
{
    "my_relation_field": "09ca9f4fe9304123b05656d9c449b1ad",
}
```